### PR TITLE
Add docker-compose configuration

### DIFF
--- a/compose/keys.yml.example
+++ b/compose/keys.yml.example
@@ -1,0 +1,3 @@
+api: http://thorium:8080/api
+username: admin
+password: password

--- a/compose/thorium.yml.example
+++ b/compose/thorium.yml.example
@@ -1,0 +1,40 @@
+thorium:
+  interface: "0.0.0.0"
+  port: 8080
+  namespace: "thorium"
+  secret_key: "CHANGE_ME"
+  tracing:
+    local:
+      level: "Info"
+  files:
+    password: "SecretCornIsBest"
+    bucket: "thorium-files"
+  results:
+    bucket: "thorium-results"
+  ephemeral:
+    bucket: "thorium-ephemeral"
+  attachments:
+    bucket: "thorium-attachments"
+  repos:
+    bucket: "thorium-repos"
+  s3:
+    access_key: "minio"
+    secret_token: "minio123"
+    endpoint: "http://minio:9000"
+    region: "us-east-1"
+  retention:
+    data: 10
+    logs: 10
+  web_ui:
+    version: "0.0.0"
+redis:
+  host: "redis"
+  port: 6379
+scylla:
+  nodes:
+    - "scylla"
+  replication: 1
+elastic:
+  node: "http://elasticsearch:9200"
+  username: "elastic"
+  password: "changeme"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,80 @@
+version: '3.8'
+
+services:
+  thorium:
+    image: ghcr.io/sandialabs/thorium:latest
+    command: ["thorium", "--config", "/conf/thorium.yml"]
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./compose/thorium.yml:/conf/thorium.yml:ro
+      - ./compose/keys.yml:/keys/keys.yml:ro
+    depends_on:
+      - redis
+      - scylla
+      - elasticsearch
+      - minio
+
+  scaler:
+    image: ghcr.io/sandialabs/thorium-scaler:latest
+    command: ["thorium-scaler", "--config", "/conf/thorium.yml", "--auth", "/keys/keys.yml", "--scaler", "K8s"]
+    volumes:
+      - ./compose/thorium.yml:/conf/thorium.yml:ro
+      - ./compose/keys.yml:/keys/keys.yml:ro
+    depends_on:
+      - thorium
+
+  search-streamer:
+    image: ghcr.io/sandialabs/thorium-search-streamer:latest
+    command: ["thorium-search-streamer", "--config", "/conf/thorium.yml", "--keys", "/keys/keys.yml", "--workers", "1"]
+    volumes:
+      - ./compose/thorium.yml:/conf/thorium.yml:ro
+      - ./compose/keys.yml:/keys/keys.yml:ro
+    depends_on:
+      - thorium
+
+  event-handler:
+    image: ghcr.io/sandialabs/thorium-event-handler:latest
+    command: ["thorium-event-handler", "--config", "/conf/thorium.yml", "--auth", "/keys/keys.yml"]
+    volumes:
+      - ./compose/thorium.yml:/conf/thorium.yml:ro
+      - ./compose/keys.yml:/keys/keys.yml:ro
+    depends_on:
+      - thorium
+
+  redis:
+    image: redis:7
+    volumes:
+      - redis-data:/data
+
+  scylla:
+    image: scylladb/scylla:5.2
+    command: --smp 1 --memory 1G --overprovisioned 1
+    volumes:
+      - scylla-data:/var/lib/scylla
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.0
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    volumes:
+      - elastic-data:/usr/share/elasticsearch/data
+
+  minio:
+    image: quay.io/minio/minio:RELEASE.2024-01-16T21-00-31Z
+    command: server /data --console-address :9001
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    volumes:
+      - minio-data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+volumes:
+  redis-data:
+  scylla-data:
+  elastic-data:
+  minio-data:


### PR DESCRIPTION
## Summary
- add example thorium configuration and auth keys for Docker Compose
- add a simple docker-compose.yml for running Thorium components and dependencies

## Testing
- `cargo check -q` *(fails: failed to read `/workspace/cart-rs/Cargo.toml`)*
- `docker-compose config -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1e9688d4832f893f311d5049a8f9