### PR TITLE
Add operator container build recipe

### DIFF
--- a/minithor/README.md
+++ b/minithor/README.md
@@ -47,6 +47,16 @@ cat .dockerconfigjson
 
 Once this registry auth file has been created, copy the file (default path is `~/.docker/config.json` for most linux systems, must be manually created on mac) to the project directory and rename it to `.dockerconfigjson`.
 
+### Build the operator image
+
+The Thorium operator runs in its own container. Build the image before deploying:
+
+```bash
+docker build -f operator/Dockerfile -t thorium-operator:latest .
+# if using Minikube, load the image into its cache
+minikube image load thorium-operator:latest
+```
+
 ### Deploy Dependencies
 
 Thorium requires persistent storage interfaces a tracing API and an operator. Lets deploy these dependencies.

--- a/minithor/infrastructure/thorium/operator.yml
+++ b/minithor/infrastructure/thorium/operator.yml
@@ -17,9 +17,9 @@ spec:
       serviceAccountName: thorium
       automountServiceAccountToken: true
       containers:
-        - name: operator
-          image: <OPERATOR IMAGE>
-          imagePullPolicy: Always
+          - name: operator
+            image: thorium-operator:latest
+            imagePullPolicy: Always
           #command: ["/bin/bash", "-c"]
           #args: ["sleep 1000"]
           resources:

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,0 +1,11 @@
+# Build the thorium operator binary
+FROM rust:1.91 as builder
+WORKDIR /build
+COPY . .
+RUN RUSTFLAGS="-C target-feature=+aes,+sse2" cargo +nightly build --release -p thorium-operator
+
+# Create minimal runtime image
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY --from=builder /build/target/release/thorium-operator /usr/local/bin/thorium-operator
+ENTRYPOINT ["/usr/local/bin/thorium-operator", "operate"]


### PR DESCRIPTION
## Summary
- replace placeholder operator image with `thorium-operator:latest`
- document and provide Dockerfile for building the operator image

## Testing
- `cargo +nightly test -p thorium-operator`
- `docker build -f operator/Dockerfile -t thorium-operator:latest .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890b816081c832f8e8133cd2584977d