### PR TITLE
Fix operator Docker build requiring nightly toolchain

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,8 @@
 FROM rust:1.81 as builder
 WORKDIR /build
 COPY . .
-RUN RUSTFLAGS="-C target-feature=+aes,+sse2" cargo +nightly build --release -p thorium-operator
+RUN rustup toolchain install nightly \
+    && RUSTFLAGS="-C target-feature=+aes,+sse2" cargo +nightly build --release -p thorium-operator
 
 # Create minimal runtime image
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary
- install nightly Rust toolchain before building the operator

## Testing
- `RUSTFLAGS="-C target-feature=+aes,+sse2" cargo +nightly test -p thorium-operator` *(fails: build terminated early due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6890c9c3ed48832fa14e8405d6c4883e